### PR TITLE
Fix ES Module Output

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run lint && npm run test:karma",
     "test:karma": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
     "lint": "eslint src test",
-    "build": "rollup -c",
+    "build": "./node_modules/.bin/rollup -c",
     "prepublishOnly": "npm run clean && npm run test && npm run build"
   },
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ export default [
 	{
 		input: 'src/index.js',
 		output: [
-			{ file: pkg.main, format: 'es' }
+			{ file: pkg.main, format: 'esm' }
 		],
 		plugins: [
 			babel({


### PR DESCRIPTION
This PR makes two changes:
* The `rollup` referenced in `npm run build` was swapped to use the executable found in node modules
* The format for the rollup config was changed to use es module output, I'm not certain that [`es` is a valid option for format (search for `output.format`)](https://rollupjs.org/guide/en/#core-functionality), and the output from rollup didn't seem to contain our export? 
![image](https://user-images.githubusercontent.com/1714798/64655883-99143080-d3fb-11e9-873c-cfef4f7c1e55.png)
