### PR TITLE
Using snippet options object for FullStory.init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ jspm_packages
 # Dist
 dist
 
-others
+# others
 .DS_Store
+.vscode

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ const init = (options) => {
   snippet(options);
 };
 
-const checkInit = (fn, message) => (...args) => {
+const initOnce = (fn, message) => (...args) => {
   if (window._fs_initialized) {
     // eslint-disable-next-line no-console
     if (message) console.warn(message);
@@ -47,6 +47,6 @@ const checkInit = (fn, message) => (...args) => {
   window._fs_initialized = true;
 };
 
-wrappedFS.init = checkInit(init, 'FullStory init has already been called once. Additional invocations are ignored');
+wrappedFS.init = initOnce(init, 'FullStory init has already been called once. Additional invocations are ignored');
 
 export default wrappedFS;

--- a/src/index.js
+++ b/src/index.js
@@ -27,35 +27,26 @@ const wrappedFS = ['event', 'log', 'getCurrentSessionURL', 'identify', 'setUserV
   return acc;
 }, {});
 
-const init = (fsOrgId, fsNamespace = 'FS', fsDebug = false, fsHost = 'fullstory.com') => {
+const init = (options) => {
   if (fs()) {
     // eslint-disable-next-line no-console
     console.warn('The FullStory snippet has already been defined elsewhere (likely in the <head> element)');
     return;
   }
 
-  snippet({
-    fsOrgId,
-    fsNamespace,
-    fsDebug,
-    fsHost
-  });
+  snippet(options);
 };
 
-const once = (fn, message) => {
-  let called = false;
-
-  return (...args) => {
-    if (called) {
-      // eslint-disable-next-line no-console
-      if (message) console.warn(message);
-      return;
-    }
-    fn(...args);
-    called = true;
-  };
+const checkInit = (fn, message) => (...args) => {
+  if (window._fs_initialized) {
+    // eslint-disable-next-line no-console
+    if (message) console.warn(message);
+    return;
+  }
+  fn(...args);
+  window._fs_initialized = true;
 };
 
-wrappedFS.init = once(init, 'FullStory init has already been called once. Additional invocations are ignored');
+wrappedFS.init = checkInit(init, 'FullStory init has already been called once. Additional invocations are ignored');
 
 export default wrappedFS;

--- a/src/snippet.js
+++ b/src/snippet.js
@@ -1,21 +1,26 @@
+/* eslint-disable */
 const snippet = (
   {
-    fsOrgId,
-    fsNamespace = 'FS',
-    fsDebug = false,
-    fsHost = 'fullstory.com'
+    orgId,
+    namespace = 'FS',
+    debug = false,
+    host = 'fullstory.com',
+    scriptSrc = 'edge.fullstory.com/s/fs.js'
   }
 ) => {
+  if (!orgId) {
+    throw new Error('FullStory orgId is a required parameter');
+  }
   /* begin FullStory snippet */
-  /* eslint-disable */
-  window._fs_debug = fsDebug;
-  window._fs_host = fsHost;
-  window._fs_org = fsOrgId;
-  window._fs_namespace = fsNamespace;
+  window._fs_debug = debug;
+  window._fs_host = host;
+  window._fs_org = orgId;
+  window._fs_namespace = namespace;
+  window._fs_script = scriptSrc;
   (function(m,n,e,t,l,o,g,y){
     if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
     g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
-    o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+m._fs_host+'/s/fs.js';
+    o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+window._fs_script;
     y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
     g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
     g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
@@ -24,7 +29,6 @@ const snippet = (
     g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
     g.clearUserCookie=function(){};
   })(window,document,window['_fs_namespace'],'script','user');
-  /* eslint-enable */
   /* end FullStory snippet */
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -24,17 +24,17 @@ describe('core', () => {
 
     functions.forEach(i => assert(typeof FullStory[i] === 'function', `${i} has not been exported from the FullStory module`));
   });
-
-  it('should throw error if API called before init', () => {
-    expect(() => { FullStory.log(); }).to.throw();
-    FullStory.init({ orgId: testOrg });
-    expect(() => { FullStory.log(); }).to.not.throw();
-  });
 });
 
 describe('init', () => {
   it('should throw error if not initialized with an orgId', () => {
     expect(() => { FullStory.init(); }).to.throw();
+  });
+
+  it('should throw error if API called before init', () => {
+    expect(() => { FullStory.log(); }).to.throw();
+    FullStory.init({ orgId: testOrg });
+    expect(() => { FullStory.log(); }).to.not.throw();
   });
 
   it('should add _fs_org value to window object', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,14 @@ import FullStory from '../src';
 
 const testOrg = '123';
 
+beforeEach(() => {
+  if (window[window._fs_namespace]) {
+    delete window._fs_initialized;
+    delete window[window._fs_namespace];
+    delete window._fs_namespace;
+  }
+});
+
 describe('core', () => {
   it('should define snippet functions', () => {
     const functions = ['event',
@@ -17,16 +25,20 @@ describe('core', () => {
     functions.forEach(i => assert(typeof FullStory[i] === 'function', `${i} has not been exported from the FullStory module`));
   });
 
-  it('should throw error if called before init', () => {
+  it('should throw error if API called before init', () => {
     expect(() => { FullStory.log(); }).to.throw();
-    FullStory.init(testOrg);
+    FullStory.init({ orgId: testOrg });
     expect(() => { FullStory.log(); }).to.not.throw();
   });
 });
 
 describe('init', () => {
+  it('should throw error if not initialized with an orgId', () => {
+    expect(() => { FullStory.init(); }).to.throw();
+  });
+
   it('should add _fs_org value to window object', () => {
-    FullStory.init(testOrg);
+    FullStory.init({ orgId: testOrg });
     expect(window._fs_org).to.equal(testOrg);
   });
 });


### PR DESCRIPTION
I've refactored the parameterized function signature for `FullStory.init` to use an options argument. This also applies to the `snippet` function as well.

Additional changes:

- added `_fs_script` to snippet - this reflects the latest change to the snippet made by the RiR team
- removed the `fs` prefix from snippet option key names
- throwing an error if `orgId` is not provided as a snippet option and added a test
- updated tests; now cleaning up the `window` object before each test to return to pre-initialized state