### PR TITLE
adding hold and deploy steps to CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
       - run:
           name: Install
           command: npm ci && (cd .github/actions/sync-snippet-action && npm ci)
-
       - save_cache:
           paths:
             - node_modules
@@ -32,6 +31,9 @@ jobs:
       - run:
           name: Test
           command: npm test
+      - run:
+          name: Build
+          command: npm run build
       - persist_to_workspace:
           root: .
           paths: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,3 @@
-masterBranchOnly: &masterBranchOnly
-  filters:
-    branches:
-      only: "master"
-
 version: 2.1
 executors:
   browser-executor:
@@ -57,8 +52,9 @@ workflows:
           type: approval
           requires:
             - build-browser-sdk
-          <<: *masterBranchOnly
+          filters:
+            branches:
+              only: "master"
       - deploy-browser-sdk:
           requires:
             - hold
-          <<: *masterBranchOnly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,8 @@
+masterBranchOnly: &masterBranchOnly
+  filters:
+    branches:
+      only: "master"
+
 version: 2.1
 executors:
   browser-executor:
@@ -46,9 +51,12 @@ workflows:
   test-deploy:
     jobs:
       - build-browser-sdk
-#      - deploy-browser-sdk:
-#          requires:
-#           - build-browser-sdk
-#         filters:
-#           branches:
-#             only: "master"
+      - hold:
+          type: approval
+          requires:
+            - build-browser-sdk
+          <<: *masterBranchOnly
+      - deploy-browser-sdk:
+          requires:
+            - hold
+          <<: *masterBranchOnly

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import App from './App';
 import FullStory from 'TBD/package-to-be-deployed';
 
 
-FullStory.init('<your org id here>');
+FullStory.init({ orgId: '<your org id here>' });
 
 ReactDOM.render(<App />, document.getElementById('root'));
 ```

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "test": "npm run lint && npm run test:karma",
     "test:karma": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
     "lint": "eslint src test .github/actions",
-    "build": "tsc src/index.d.ts && rollup -c",
-    "prepublishOnly": "npm run clean && npm run test && npm run build"
+    "build": "tsc src/index.d.ts && rollup -c"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This is a simple three job workflow:

Build & Test --> Hold --> Deploy to NPM

Here's a sample pipeline on a test project: https://circleci.com/workflow-run/5bf54a02-19eb-4d7e-b58e-c3510969586b