### PR TITLE
Remove github action context

### DIFF
--- a/.github/actions/sync-snippet-action/main.js
+++ b/.github/actions/sync-snippet-action/main.js
@@ -48,7 +48,7 @@ const run = async () => {
   }
 
   console.log('getting source tree from master');
-  const getCommitResponse  = await octokit.git.getCommit({
+  const getCommitResponse = await octokit.git.getCommit({
     ...repoInfo,
     commit_sha: LATEST_COMMIT_SHA,
   });


### PR DESCRIPTION
While I was developing the GitHub Action that checks for the latest version of the snippet, I was using a workflow triggered by a `push`, which allowed me to test my code changes immediately: I'd change code, `push` it to the repo, trigger the action, and verify the results (on a forked repo).

I was using a `context` object from the `github` package to get access to information about the currently executing repository and branch. However, when I switched from a `push` trigger to a `schedule` trigger, the `context` object changed and the properties I relied on were not available.

This PR replaces the `context` object with references to stable [environment variables](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables) that describe the repo and the branch. The functionality of the Action is the same as before.