### PR TITLE
updating the SNIPPET_ENDPOINT env var to point to the prod snippet API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,5 +16,5 @@ jobs:
     - name: Sync snippet
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SNIPPET_ENDPOINT: https://api.staging.fullstory.com/code/v1/snippet?type=esm
+        SNIPPET_ENDPOINT: https://api.fullstory.com/code/v1/snippet?type=esm
       uses: ./.github/actions/sync-snippet-action


### PR DESCRIPTION
The production `/code/v1/snippet` endpoint is live! this PR updates the GitHub Action to poll the prod endpoint.