### PR TITLE
hard-coding base value when creating PR per GitHub support recommendation

### DIFF
--- a/.github/actions/sync-snippet-action/main.js
+++ b/.github/actions/sync-snippet-action/main.js
@@ -13,7 +13,6 @@ const {
   GITHUB_REPOSITORY,
   GITHUB_TOKEN,
   GITHUB_SHA,
-  GITHUB_REF
 } = process.env;
 
 const hash = text => crypto.createHash('sha256').update(text).digest('hex');
@@ -106,7 +105,7 @@ const run = async () => {
     ...repoInfo,
     title: PR_TITLE,
     head: branchName,
-    base: GITHUB_REF, // 'refs/heads/master' if action is running on master branch
+    base: 'master', // hard-coding this value, rather than use GITHUB_REF env var as a work-around to a bug in GitHub
   });
 
   const maintainers = JSON.parse(fs.readFileSync('./MAINTAINERS.json'));


### PR DESCRIPTION
GitHub support got back to me with a cause and work-around for an issue where we can't merge PRs created by the GitHub Action. This PR implements the work-around. More details about the bug from GH support:

> The cause of the issue here is a bit obscure, and fundamentally a bug on our end. We're already working on a long-term fix in the product, but in the meantime, I've included an explanation and workaround below.

> It turns out that the base ref specified in the pull request created by GitHub Actions is refs/heads/master. A typical, user-created pull request would have instead specified a base ref of just master.

> The fully qualified base ref provided by GitHub Actions is equivalent to master in most contexts, but for one issue: it prevents our protected branch checks from locating required reviews, as we only search for reviews attached to a base ref without the refs/heads/ prefix. For this reason, our checks couldn't detect the various approvals you and your colleagues had provided, hence the perplexing error.

@jhump 