### PR TITLE
Use named exports 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-import FullStory from '@fullstorydev/browser';
+import * as FullStory from '@fullstorydev/browser';
 
 
 FullStory.init({ orgId: '<your org id here>' });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstorydev/browser",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "The official FullStory browser SDK",
   "repository": "git://github.com/fullstorydev/fullstory-browser-sdk.git",
   "homepage": "https://github.com/fullstorydev/fullstory-browser-sdk",

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const wrappedFS = ['event', 'log', 'getCurrentSessionURL', 'identify', 'setUserV
   return acc;
 }, {});
 
-const init = (options) => {
+const _init = (options) => {
   if (fs()) {
     // eslint-disable-next-line no-console
     console.warn('The FullStory snippet has already been defined elsewhere (likely in the <head> element)');
@@ -47,7 +47,31 @@ const initOnce = (fn, message) => (...args) => {
   window._fs_initialized = true;
 };
 
-wrappedFS.init = initOnce(init, 'FullStory init has already been called once, additional invocations are ignored');
+wrappedFS.init = initOnce(_init, 'FullStory init has already been called once, additional invocations are ignored');
 wrappedFS.anonymize = () => wrappedFS.identify(false);
 
-export default wrappedFS;
+const {
+  anonymize,
+  consent,
+  event,
+  getCurrentSessionURL,
+  identify,
+  init,
+  log,
+  restart,
+  setUserVars,
+  shutdown,
+} = wrappedFS;
+
+export {
+  anonymize,
+  consent,
+  event,
+  getCurrentSessionURL,
+  identify,
+  init,
+  log,
+  restart,
+  setUserVars,
+  shutdown,
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import { assert, expect } from 'chai';
-import FullStory from '../src';
+import * as FullStory from '../src';
 
 const testOrg = '123';
 


### PR DESCRIPTION
Sentry is working on building a TypeScript integration with `@fullstorydev/browser` and discovered an inconsistency in the way we export functions. We `default export` an object in the JavaScript source code, but our typings file exports functions individually (no `default`). This PR changes the JavaScript source code to use named exports, which is consistent with how functions are defined in `index.d.ts`.

This is related to https://github.com/fullstorydev/fullstory-browser-sdk/issues/34