### PR TITLE
Add iFrameOption to snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Call the `init()` function with options as soon as you can in your website start
 | ------ | -------- | ----------- |
 | orgId  | yes | Your FullStory Org ID |
 | debug | no | Enables FullStory recording debug messages; defaults to `false` |
-| iFrameOption | no | Controls recording of iFrames; read the security implications if using `RecordCrossDomainIFrame` in [help](https://help.fullstory.com/hc/en-us/articles/360020622514) |
+| iFrameOption | no | Controls recording of iFrames: use either `RecordCrossDomainIFrame` or `RecordOnlyIFrame`. Before using `RecordCrossDomainIFrame`, review the security note for `_fs_run_in_iframe` in [help](https://help.fullstory.com/hc/en-us/articles/360020622514). |
 | namespace | no | Global identifier of FullStory used when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-) |
 
 Here's an example of what this would look like in a React app:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ yarn add @fullstory/browser
 
 ## Initialize the SDK
 
-Call the `init()` function as soon as you can in your website startup process. 
+Call the `init()` function with options as soon as you can in your website startup process.
+
+| Option | Required | Description |
+| ------ | -------- | ----------- |
+| orgId  | yes | Your FullStory Org ID |
+| debug | no | Enables FullStory recording debug messages; defaults to `false` |
+| iFrameOption | no | Controls recording of iFrames; read the security implications if using `RecordCrossDomainIFrame` in [help](https://help.fullstory.com/hc/en-us/articles/360020622514) |
+| namespace | no | Global identifier of FullStory used when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-) |
 
 Here's an example of what this would look like in a React app:
 ```JSX

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,15 @@ interface SnippetOptions {
   debug?: boolean;
   host?: string;
   script?: string;
+  iFrameOption?: IFrameOption;
+}
+
+// recording options for iframes
+// `RecordCrossDomainIFrame` has security implications
+// see https://help.fullstory.com/hc/en-us/articles/360020622514
+export enum IFrameOption {
+  RecordCrossDomainIFrame = '_fs_run_in_iframe',
+  RecordOnlyIFrame = '_fs_is_outer_script',
 }
 
 interface UserVars {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,13 +4,13 @@ interface SnippetOptions {
   debug?: boolean;
   host?: string;
   script?: string;
-  iFrameOption?: IFrameOption;
+  iFrameOption?: IFrameOptions;
 }
 
 // recording options for iframes
 // `RecordCrossDomainIFrame` has security implications
 // see https://help.fullstory.com/hc/en-us/articles/360020622514
-export enum IFrameOption {
+export enum IFrameOptions {
   RecordCrossDomainIFrame = '_fs_run_in_iframe',
   RecordOnlyIFrame = '_fs_is_outer_script',
 }

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ export const shutdown = guard('shutdown');
 export const restart = guard('restart');
 export const anonymize = guard('anonymize');
 export const init = initOnce(_init, 'FullStory init has already been called once, additional invocations are ignored');
-export const IFrameOption = {
+export const IFrameOptions = {
   RecordCrossDomainIFrame: '_fs_run_in_iframe',
   RecordOnlyIFrame: '_fs_is_outer_script',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -52,3 +52,7 @@ export const shutdown = guard('shutdown');
 export const restart = guard('restart');
 export const anonymize = guard('anonymize');
 export const init = initOnce(_init, 'FullStory init has already been called once, additional invocations are ignored');
+export const IFrameOption = {
+  RecordCrossDomainIFrame: '_fs_run_in_iframe',
+  RecordOnlyIFrame: '_fs_is_outer_script',
+};

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,10 @@ const _init = (options) => {
     return;
   }
 
+  if (options.iFrameOption) {
+    window[options.iFrameOption] = true;
+  }
+
   snippet(options);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,23 @@ describe('init', () => {
     FullStory.init({ orgId: testOrg });
     expect(window._fs_org).to.equal(testOrg);
   });
+
+  it('should add _fs_run_in_iframe value to window object', () => {
+    FullStory.init({
+      orgId: testOrg,
+      iFrameOption: FullStory.IFrameOption.RecordCrossDomainIFrame,
+    });
+    console.log(`iframeoption ${window.iframeoption}`);
+    expect(window._fs_run_in_iframe).to.equal(true);
+  });
+
+  it('should add _fs_is_outer_script value to window object', () => {
+    FullStory.init({
+      orgId: testOrg,
+      iFrameOption: FullStory.IFrameOption.RecordOnlyIFrame,
+    });
+    expect(window._fs_is_outer_script).to.equal(true);
+  });
 });
 
 describe('getCurrentSessionURL', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -47,7 +47,7 @@ describe('init', () => {
   it('should add _fs_run_in_iframe value to window object', () => {
     FullStory.init({
       orgId: testOrg,
-      iFrameOption: FullStory.IFrameOption.RecordCrossDomainIFrame,
+      iFrameOption: FullStory.IFrameOptions.RecordCrossDomainIFrame,
     });
     expect(window._fs_run_in_iframe).to.equal(true);
   });
@@ -55,7 +55,7 @@ describe('init', () => {
   it('should add _fs_is_outer_script value to window object', () => {
     FullStory.init({
       orgId: testOrg,
-      iFrameOption: FullStory.IFrameOption.RecordOnlyIFrame,
+      iFrameOption: FullStory.IFrameOptions.RecordOnlyIFrame,
     });
     expect(window._fs_is_outer_script).to.equal(true);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -49,7 +49,6 @@ describe('init', () => {
       orgId: testOrg,
       iFrameOption: FullStory.IFrameOption.RecordCrossDomainIFrame,
     });
-    console.log(`iframeoption ${window.iframeoption}`);
     expect(window._fs_run_in_iframe).to.equal(true);
   });
 


### PR DESCRIPTION
This PR fixes #1 and adds control over the snippet's iFrame recording options as seen in [Can FullStory capture content that is presented in iframes](https://help.fullstory.com/hc/en-us/articles/360020622514).

## Naming conventions
I opted for the following properties:
`RecordCrossDomainIFrame`
`RecordOnlyIFrame`

The *Record* prefix better specifies what the property controls.  As in `RecordCrossDomainIFrame` records cross domain IFrames.  The other `RecordOnlyIFrame` differs from the previously proposed `OnlyInHostIFrame`.  To me, it's not clear only in host iframe means, and the underlying `_fs_is_outer_script` value is even more opaque.  So I chose an option that implies only the iFrame will be recorded.  Let me know if that's still not simple enough.

## Readme
I added an options table to describe these new options as well as a few others.  I've omitted the `script` and `host` options intentionally as these are more advanced needs, and I don't want devs to shoot themselves in the foot.

## Code

There are two changes, one to the declaration file and the other to the JavaScript.

The following typescript enum:

```
export enum IFrameOption {
  RecordCrossDomainIFrame = '_fs_run_in_iframe',
  RecordOnlyIFrame = '_fs_is_outer_script',
}
```
normally gets transpiled to:

```
var IFrameOption;
(function (IFrameOption) {
    IFrameOption["RecordCrossDomainIFrame"] = "_fs_run_in_iframe";
    IFrameOption["RecordOnlyIFrame"] = "_fs_is_outer_script";
})(IFrameOption = exports.IFrameOption || (exports.IFrameOption = {}));
```

This is a bit obtuse (not to mention the lint errors it generates), and I simply re-wrote that as an exported object:

```
export const IFrameOption = {
  RecordCrossDomainIFrame: '_fs_run_in_iframe',
  RecordOnlyIFrame: '_fs_is_outer_script',
};
```

