### PR TITLE
Adds iframe options to SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.4
+
+* Added init() options that control IFrame recording
+* Updated README to include option descriptions and usage
+* Updated README with Angular example
+
 ## 1.2.3
 
 * Incorporate FS.anonymize method now included in the core snippet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.4
+## 1.3.0
 
 * Added init() options that control IFrame recording
 * Updated README to include option descriptions and usage

--- a/README.md
+++ b/README.md
@@ -20,9 +20,18 @@ yarn add @fullstory/browser
 
 ## Initialize the SDK
 
-Call the `init()` function as soon as you can in your website startup process. 
+Call the `init()` function with options as soon as you can in your website startup process.
 
-Here's an example of what this would look like in a React app:
+| Option | Required | Description |
+| ------ | -------- | ----------- |
+| orgId  | yes | Sets your FullStory Org ID. |
+| debug | no | When set to `true`, enables FullStory debug messages; defaults to `false`. |
+| namespace | no | Sets the global identifier for FullStory when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-). |
+| recordCrossDomainIFrames | no | When set to `true`, FullStory is added to cross-domain IFrames and records content; defaults to `false`. Before using, you should understand the security implications, and configure your [Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/) (CSP) HTTP headers accordingly - specifically the frame-ancestors directive. Failure to configure your CSP headers while using this setting can bypass IFrames security protections that are included in modern browsers. |
+| recordOnlyThisIFrame | no | When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org. |
+
+Here's an example of initializing the SDK in a React app.
+
 ```JSX
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -36,7 +45,27 @@ FullStory.init({ orgId: '<your org id here>' });
 ReactDOM.render(<App />, document.getElementById('root'));
 ```
 
-## Examples
+Here's an example of initializing the SDK in an Angular app.
+
+```javascript
+import { Component } from '@angular/core';
+import * as FullStory from '@fullstory/browser';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['./app.component.scss']
+})
+export class AppComponent {
+
+  constructor() {
+    FullStory.init({ orgId: '<your org id here>', recordCrossDomainIFrames: true });
+  }
+}
+
+```
+
+## Using the SDK
 
 Once FullStory is initialized, you can make calls to the FullStory SDK.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ FullStory.init({ orgId: '<your org id here>' });
 ReactDOM.render(<App />, document.getElementById('root'));
 ```
 
-Here's an example of initializing the SDK in an Angular app.
+Here's an example of initializing the SDK in an Angular app with debug enabled for troubleshooting purposes.
 
 ```javascript
 import { Component } from '@angular/core';
@@ -59,10 +59,9 @@ import * as FullStory from '@fullstory/browser';
 export class AppComponent {
 
   constructor() {
-    FullStory.init({ orgId: '<your org id here>', recordCrossDomainIFrames: true });
+    FullStory.init({ orgId: '<your org id here>', debug: true });
   }
 }
-
 ```
 
 ## Using the SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/browser",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/browser",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/browser",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "The official FullStory browser SDK",
   "repository": "git://github.com/fullstorydev/fullstory-browser-sdk.git",
   "homepage": "https://github.com/fullstorydev/fullstory-browser-sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/browser",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "The official FullStory browser SDK",
   "repository": "git://github.com/fullstorydev/fullstory-browser-sdk.git",
   "homepage": "https://github.com/fullstorydev/fullstory-browser-sdk",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,8 @@ interface SnippetOptions {
   debug?: boolean;
   host?: string;
   script?: string;
+  recordCrossDomainIFrames?: boolean;
+  recordOnlyThisIFrame?: boolean;      // see README for details
 }
 
 interface UserVars {

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,16 @@ const _init = (options) => {
     return;
   }
 
+  // inject FullStory into cross domain iFrames and record them
+  if (options.recordCrossDomainIFrames) {
+    window._fs_run_in_iframe = true;
+  }
+
+  // record the contents of this iFrame when embedded in a parent site
+  if (options.recordOnlyThisIFrame) {
+    window._fs_is_outer_script = true;
+  }
+
   snippet(options);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,22 @@ describe('init', () => {
     FullStory.init({ orgId: testOrg });
     expect(window._fs_org).to.equal(testOrg);
   });
+
+  it('should add _fs_run_in_iframe value to window object', () => {
+    FullStory.init({
+      orgId: testOrg,
+      recordCrossDomainIFrames: true,
+    });
+    expect(window._fs_run_in_iframe).to.equal(true);
+  });
+
+  it('should add _fs_is_outer_script value to window object', () => {
+    FullStory.init({
+      orgId: testOrg,
+      recordOnlyThisIFrame: true,
+    });
+    expect(window._fs_is_outer_script).to.equal(true);
+  });
 });
 
 describe('getCurrentSessionURL', () => {


### PR DESCRIPTION
This PR fixes #1 and adds control over the snippet's iFrame recording options as seen in [Can FullStory capture content that is presented in iframes](https://help.fullstory.com/hc/en-us/articles/360020622514-Can-FullStory-capture-content-that-is-presented-in-iframes-).