### PR TITLE
updating readme to show init config options as a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ Call the `init()` function with options as soon as you can in your website start
 
 ### Configuration Options
 
-##### orgId (required)
+#### `orgId` (required)
 Sets your FullStory Org ID.
 
-##### debug (optional)
+#### `debug` (optional)
 When set to `true`, enables FullStory debug messages; defaults to `false`.
 
-##### namespace (optional)
+#### `namespace` (optional)
 Sets the global identifier for FullStory when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-).
 
-##### recordCrossDomainIFrames (optional)
+#### `recordCrossDomainIFrames` (optional)
 When set to `true`, FullStory is added to cross-domain IFrames and records content; defaults to `false`. Before using, you should understand the security implications, and configure your [Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/) (CSP) HTTP headers accordingly - specifically the frame-ancestors directive. Failure to configure your CSP headers while using this setting can bypass IFrames security protections that are included in modern browsers.
 
-##### recordOnlyThisIFrame (optional)
+#### `recordOnlyThisIFrame` (optional)
 When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org.
 
 Here's an example of initializing the SDK in a React app.

--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ Call the `init()` function with options as soon as you can in your website start
 
 ### Configuration Options
 
-#### orgId (required)
+##### orgId (required)
 Sets your FullStory Org ID.
 
-#### debug (optional)
+##### debug (optional)
 When set to `true`, enables FullStory debug messages; defaults to `false`.
 
-#### namespace (optional)
+##### namespace (optional)
 Sets the global identifier for FullStory when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-).
 
-#### recordCrossDomainIFrames (optional)
+##### recordCrossDomainIFrames (optional)
 When set to `true`, FullStory is added to cross-domain IFrames and records content; defaults to `false`. Before using, you should understand the security implications, and configure your [Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/) (CSP) HTTP headers accordingly - specifically the frame-ancestors directive. Failure to configure your CSP headers while using this setting can bypass IFrames security protections that are included in modern browsers.
 
-#### recordOnlyThisIFrame (optional)
+##### recordOnlyThisIFrame (optional)
 When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org.
 
 Here's an example of initializing the SDK in a React app.

--- a/README.md
+++ b/README.md
@@ -24,20 +24,11 @@ Call the `init()` function with options as soon as you can in your website start
 
 ### Configuration Options
 
-#### `orgId` (required)
-Sets your FullStory Org ID.
-
-#### `debug` (optional)
-When set to `true`, enables FullStory debug messages; defaults to `false`.
-
-#### `namespace` (optional)
-Sets the global identifier for FullStory when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-).
-
-#### `recordCrossDomainIFrames` (optional)
-When set to `true`, FullStory is added to cross-domain IFrames and records content; defaults to `false`. Before using, you should understand the security implications, and configure your [Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/) (CSP) HTTP headers accordingly - specifically the frame-ancestors directive. Failure to configure your CSP headers while using this setting can bypass IFrames security protections that are included in modern browsers.
-
-#### `recordOnlyThisIFrame` (optional)
-When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org.
+*  `orgId` (required) -  Sets your FullStory Org ID.
+*  `debug` (optional) - When set to `true`, enables FullStory debug messages; defaults to `false`.
+* `namespace` (optional) - Sets the global identifier for FullStory when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-).
+* `recordCrossDomainIFrames` (optional) - When set to `true`, FullStory is added to cross-domain IFrames and records content; defaults to `false`. Before using, you should understand the security implications, and configure your [Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/) (CSP) HTTP headers accordingly - specifically the frame-ancestors directive. Failure to configure your CSP headers while using this setting can bypass IFrames security protections that are included in modern browsers.
+* `recordOnlyThisIFrame` (optional) - When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org.
 
 ### Initialization Examples
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Call the `init()` function with options as soon as you can in your website start
 
 ### Configuration Options
 
-*  `orgId` (required) -  Sets your FullStory Org ID.
-*  `debug` (optional) - When set to `true`, enables FullStory debug messages; defaults to `false`.
-* `namespace` (optional) - Sets the global identifier for FullStory when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-).
-* `recordCrossDomainIFrames` (optional) - When set to `true`, FullStory is added to cross-domain IFrames and records content; defaults to `false`. Before using, you should understand the security implications, and configure your [Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/) (CSP) HTTP headers accordingly - specifically the frame-ancestors directive. Failure to configure your CSP headers while using this setting can bypass IFrames security protections that are included in modern browsers.
-* `recordOnlyThisIFrame` (optional) - When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org.
+The only required option is `orgId`, all others are optional.
+
+*  `orgId` -  Sets your FullStory Org ID.
+*  `debug` - When set to `true`, enables FullStory debug messages; defaults to `false`.
+* `namespace` - Sets the global identifier for FullStory when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-).
+* `recordCrossDomainIFrames` - When set to `true`, FullStory is added to cross-domain IFrames and records content; defaults to `false`. Before using, you should understand the security implications, and configure your [Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/) (CSP) HTTP headers accordingly - specifically the frame-ancestors directive. Failure to configure your CSP headers while using this setting can bypass IFrames security protections that are included in modern browsers.
+* `recordOnlyThisIFrame` - When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org.
 
 ### Initialization Examples
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ When set to `true`, FullStory is added to cross-domain IFrames and records conte
 #### `recordOnlyThisIFrame` (optional)
 When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org.
 
+### Initialization Examples
+
 Here's an example of initializing the SDK in a React app.
 
 ```JSX

--- a/README.md
+++ b/README.md
@@ -22,13 +22,22 @@ yarn add @fullstory/browser
 
 Call the `init()` function with options as soon as you can in your website startup process.
 
-| Option | Required | Description |
-| ------ | -------- | ----------- |
-| orgId  | yes | Sets your FullStory Org ID. |
-| debug | no | When set to `true`, enables FullStory debug messages; defaults to `false`. |
-| namespace | no | Sets the global identifier for FullStory when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-). |
-| recordCrossDomainIFrames | no | When set to `true`, FullStory is added to cross-domain IFrames and records content; defaults to `false`. Before using, you should understand the security implications, and configure your [Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/) (CSP) HTTP headers accordingly - specifically the frame-ancestors directive. Failure to configure your CSP headers while using this setting can bypass IFrames security protections that are included in modern browsers. |
-| recordOnlyThisIFrame | no | When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org. |
+### Configuration Options
+
+#### orgId (required)
+Sets your FullStory Org ID.
+
+#### debug (optional)
+When set to `true`, enables FullStory debug messages; defaults to `false`.
+
+#### namespace (optional)
+Sets the global identifier for FullStory when conflicts with `FS` arise; see [help](https://help.fullstory.com/hc/en-us/articles/360020624694-What-if-the-identifier-FS-is-used-by-another-script-on-my-site-).
+
+#### recordCrossDomainIFrames (optional)
+When set to `true`, FullStory is added to cross-domain IFrames and records content; defaults to `false`. Before using, you should understand the security implications, and configure your [Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/) (CSP) HTTP headers accordingly - specifically the frame-ancestors directive. Failure to configure your CSP headers while using this setting can bypass IFrames security protections that are included in modern browsers.
+
+#### recordOnlyThisIFrame (optional)
+When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running Fullstory, but you want your content sent to a different FullStory org.
 
 Here's an example of initializing the SDK in a React app.
 


### PR DESCRIPTION
This formats the Readme so that config options are more readable on NPM.