### PR TITLE
Added a code snippet for Vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ export class AppComponent {
 }
 ```
 
+Here's an example of initializing the SDK in a Vue app.
+
+```javascript
+import Vue from "vue";
+import App from "./App.vue";
+import * as FullStory from "@fullstory/browser";
+
+FullStory.init({ orgId: "<your org id here>" });
+Vue.prototype.$FullStory = FullStory;
+
+new Vue({
+  render: h => h(App)
+}).$mount("#app");
+```
+
 ## Using the SDK
 
 Once FullStory is initialized, you can make calls to the FullStory SDK.

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ export class AppComponent {
 Here's an example of initializing the SDK in a Vue app.
 
 ```javascript
-import Vue from "vue";
-import App from "./App.vue";
-import * as FullStory from "@fullstory/browser";
+import Vue from 'vue';
+import App from './App.vue';
+import * as FullStory from '@fullstory/browser';
 
-FullStory.init({ orgId: "<your org id here>" });
+FullStory.init({ orgId: '<your org id here>' });
 Vue.prototype.$FullStory = FullStory;
 
 new Vue({
   render: h => h(App)
-}).$mount("#app");
+}).$mount('#app');
 ```
 
 ## Using the SDK


### PR DESCRIPTION
Added a code snippet on how a developer would initialize the FullStory SDK on a Vue Js app, This is also adding the SDK to the [Vue instance property](https://vuejs.org/v2/cookbook/adding-instance-properties.html#Base-Example) which will allow other Vue instances to have access to that property. 

Example calling an event from another Vue component would look like this.  
```
this.$FullStory.event("Subscribed", {
  uid_str: "750948353",
  plan_name_str: "Professional",
  plan_price_real: 299,
  plan_users_int: 10,
  days_in_trial_int: 42,
  feature_packs: ["MAPS", "DEV", "DATA"]
});
```