### PR TITLE
bump to 1.4.9 to get a green build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/browser",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/browser",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "The official FullStory browser SDK",
   "repository": "git://github.com/fullstorydev/fullstory-browser-sdk.git",
   "homepage": "https://github.com/fullstorydev/fullstory-browser-sdk",


### PR DESCRIPTION
I don't understand yet why the build is Red - Circle CI has the last several builds as Green