### PR TITLE
Support TypeScript exactOptionalPropertyTypes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,17 +1,17 @@
 interface SnippetOptions {
   orgId: string;
-  namespace?: string;
-  debug?: boolean;
-  host?: string;
-  script?: string;
-  recordCrossDomainIFrames?: boolean;
-  recordOnlyThisIFrame?: boolean;      // see README for details
-  devMode?: boolean;
+  namespace?: string | undefined;
+  debug?: boolean | undefined;
+  host?: string | undefined;
+  script?: string | undefined;
+  recordCrossDomainIFrames?: boolean | undefined;
+  recordOnlyThisIFrame?: boolean | undefined;      // see README for details
+  devMode?: boolean | undefined;
 }
 
 interface UserVars {
-  displayName?: string;
-  email?: string;
+  displayName?: string | undefined;
+  email?: string | undefined;
   [key: string]: any;
 }
 
@@ -19,9 +19,9 @@ type LogLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
 
 // API functions that are available as soon as the snippet has executed.
 export function anonymize(): void;
-export function consent(userConsents?: boolean): void;
+export function consent(userConsents?: boolean | undefined): void;
 export function event(eventName: string, eventProperties: { [key: string]: any }): void;
-export function identify(uid: string, customVars?: UserVars): void;
+export function identify(uid: string, customVars?: UserVars | undefined): void;
 export function init(options: SnippetOptions): void;
 export function log(level: LogLevel, msg: string): void;
 export function log(msg: string): void;
@@ -31,4 +31,4 @@ export function shutdown(): void;
 
 // API functions that are available after /rec/page returns.
 // FullStory bootstrapping details: https://help.fullstory.com/hc/en-us/articles/360032975773
-export function getCurrentSessionURL(now?: boolean): string | null;
+export function getCurrentSessionURL(now?: boolean | undefined): string | null;


### PR DESCRIPTION
TypeScript 4.4 added a new compiler option, `exactOptionalPropertyTypes`, which distinguishes between `{}` and `{ key: undefined }`. With this flag, `f(key?: string)`  may either be `f()` or `f('str')`, but may _not_ be `f(undefined)`. In most cases, `f(undefined)` should be acceptable, including in FullStory.

Example:

```
function myInit({ devMode, orgId }) {
  init({ devMode, orgId });
}

myInit({ orgId }); // should be valid,
```

In the above example, TypeScript 4.4 throws an error with the flag because `devMode` must either by a boolean or _not set at all_. It does not allow this code such that it is set to `undefined`.

For future consumer-facing code, please replace `[key]?: T` with `[key]?: T | undefined`. 🙃