### PR TITLE
expose setVars method on package interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,16 @@ FullStory.event('Subscribed', {
 const startOfPlayback = FullStory.getCurrentSessionURL();
 const playbackAtThisMomentInTime = FullStory.getCurrentSessionURL(true);
 ```
+
+### Sending custom page data
+```JavaScript
+FullStory.setVars("page", {
+ "pageName" : "Checkout", // what is the name of the page?
+ "cart_size_int" : 10, // how many items were in the cart?
+ "used_coupon_bool" : true, // was a coupon used?
+});
+```
+For more information on setting page vars, view the FullStory help article on [Sending custom page data to FullStory](https://help.fullstory.com/hc/en-us/articles/1500004101581-FS-setVars-API-Sending-custom-page-data-to-FullStory).
+
+#### Note
+`FullStory.setVars(<scope>, <payload>)` currently only supports a string value of "page" for the scope. Using arbitrary strings for the scope parameter will result in an Error that will be logged to the browser console or discarded, depending on whether devMode or debug is enabled.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,6 +29,8 @@ interface UserVars {
 
 type LogLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
 
+type VarScope = 'page';
+
 // API functions that are available as soon as the snippet has executed.
 export function anonymize(): void;
 export function consent(userConsents?: boolean): void;
@@ -40,6 +42,7 @@ export function log(msg: string): void;
 export function restart(): void;
 export function setUserVars(customVars: UserVars): void;
 export function shutdown(): void;
+export function setVars(varScope: VarScope, properties?: { [key: string]: any }): void;
 
 // API functions that are available after /rec/page returns.
 // FullStory bootstrapping details: https://help.fullstory.com/hc/en-us/articles/360032975773

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ export const consent = guard('consent');
 export const shutdown = guard('shutdown');
 export const restart = guard('restart');
 export const anonymize = guard('anonymize');
+export const setVars = guard('setVars');
 
 const _init = (options) => {
   if (fs()) {


### PR DESCRIPTION
This pull request exposes a new method `setVars` on the package interface. With the FS.setVars API, you can send your own custom page names and properties to FullStory. Read more about it at [help.fullstory.com](https://help.fullstory.com/hc/en-us/articles/1500004101581-FS-setVars-API-Sending-custom-page-data-to-FullStory)