### PR TITLE
Add isInitialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ yarn add @fullstory/browser
 
 ## Initialize the SDK
 
-Call the `init()` function with options as soon as you can in your website startup process.
+Call the `init()` function with options as soon as you can in your website startup process. Calling init after successful initialization will trigger console warnings - if you need to programmatically check if FullStory has been initialized at some point in your code, you can call `isInitialized()`.
 
 ### Configuration Options
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -37,6 +37,7 @@ export function consent(userConsents?: boolean): void;
 export function event(eventName: string, eventProperties: { [key: string]: any }): void;
 export function identify(uid: string, customVars?: UserVars): void;
 export function init(options: SnippetOptions): void;
+export function isInitialized(): boolean;
 export function log(level: LogLevel, msg: string): void;
 export function log(msg: string): void;
 export function restart(): void;

--- a/src/index.js
+++ b/src/index.js
@@ -80,3 +80,6 @@ const initOnce = (fn, message) => (...args) => {
 };
 
 export const init = initOnce(_init, 'FullStory init has already been called once, additional invocations are ignored');
+
+// normalize undefined into boolean
+export const isInitialized = () => !!window._fs_initialized;

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,18 @@ describe('init', () => {
 
     expect(window._fs_dev_mode).to.equal(true);
   });
+
+  it('should return whether initialized', () => {
+    let isInit = FullStory.isInitialized();
+    expect(isInit).to.equal(false);
+
+    FullStory.init({
+      orgId: testOrg,
+    });
+
+    isInit = FullStory.isInitialized();
+    expect(isInit).to.equal(true);
+  });
 });
 
 describe('devMode', () => {


### PR DESCRIPTION
This PR adds an `isInitialized` function which wraps `window._fs_initialized`. This is useful for code that could potentially repeatedly call `init` (like useEffects), leading to noisy console warnings. Checking for initialization before calling `init` would be helpful in this situation.