### PR TITLE
hold and deploy steps will only execute when a version tag is pushed to remote

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,24 @@ workflows:
   version: 2
   test-deploy:
     jobs:
-      - build-browser-sdk
+      - build-browser-sdk:
+          filters:
+            tags:
+              only: /.*/
       - hold:
           type: approval
           requires:
             - build-browser-sdk
           filters:
+            tags:
+              only: /^v.*/
             branches:
-              only: "main"
+              ignore: /.*/
       - deploy-browser-sdk:
           requires:
             - hold
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Right now, deploys are triggered from the `main` branch. This is causing false negative build failures when merging dependabot PRs.

Some background:

GH-dependabot PRs get merged into `main`, but this triggers an NPM audit on `main` build, which fails the build since there are subsequent dependabot PRs that are yet to be merged.

Eventually, after all dependabot PRs are merged, the NPM audit passes but the `main` build can't go green because it is in a Hold state. At this point the only way it can go green is to do a full deploy to NPM.

But a full deploy to NPM should be unnecessary since these are only NPM audit fixes for dev deps.

This PR now only triggers the Hold + Deploy state when a version tag (`/v.*/`) is pushed to remote.