### PR TITLE
Add a `ready` callback to the `init` function. Fixes #138

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ The only required option is `orgId`, all others are optional.
 * `recordOnlyThisIFrame` - When set to `true`, this tells FullStory that the IFrame is the "root" of the recording and should be its own session; defaults to `false`. Use this when your app is embedded in an IFrame on a site not running FullStory or when the site *is* running FullStory, but you want your content sent to a different FullStory org.
 * `devMode` - Set to `true` if you want to deactivate FullStory in your development environment. When set to `true`, FullStory will shutdown recording and all subsequent SDK method calls will be no-ops. At the time `init` is called with `devMode: true`, a single `event` call will be sent to FullStory to indicate that the SDK is in `devMode`; this is to help trouble-shoot the case that the SDK was accidentally set to `devMode: true` in a production environment. Additionally, any calls to SDK methods will `console.warn` that FullStory is in `devMode`. Defaults to `false`.
 
+### Ready Callback
+
+The `init` function also accepts an optional `readyCallback` argument. If you provide a function, it will be invoked when the FullStory session has started. Your callback will be called with one parameter: an object containing information about the session. Currently the only property is `sessionUrl`, which is a string containing the URL to the session.
+
+```javascript
+FullStory.init({ orgId, ({ sessionUrl }) => console.log(`Started session: ${sessionUrl}`));
+```
+
 ### Initialization Examples
 
 #### React

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,9 +47,9 @@ export function identify(uid: string, customVars?: UserVars): void;
  * Initialize FullStory.
  *
  * @param options Options to pass to the snippet.
- * @param ready If provided, a callback that will be invoked when the FullStory session has begun.
+ * @param readyCallback If provided, a callback that will be invoked when the FullStory session has begun.
  */
-export function init(options: SnippetOptions, ready?: ReadyCallback): void;
+export function init(options: SnippetOptions, readyCallback?: ReadyCallback): void;
 export function isInitialized(): boolean;
 export function log(level: LogLevel, msg: string): void;
 export function log(msg: string): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@
  * - debug: Debug mode with extra browser console logging.
  * - host: The recording server host domain. Can be set to direct recorded events to a proxy that you host. Defaults to `fullstory.com`.
  * - script: FullStory script host domain. FullStory hosts the `fs.js` recording script on a CDN, but you can choose to host a copy yourself. Defaults to `edge.fullstory.com`.
- * - recordCrossDomainIFrames: FullStory can record cross-domain iFrames. Defaults to `false`. Certain limitations apply and can be found [here](https://help.fullstory.com/hc/en-us/articles/360020622514-Can-FullStory-capture-content-that-is-presented-in-iframes-#h_01F1G333PYKPGZ4B42WDBV3YKV). 
+ * - recordCrossDomainIFrames: FullStory can record cross-domain iFrames. Defaults to `false`. Certain limitations apply and can be found [here](https://help.fullstory.com/hc/en-us/articles/360020622514-Can-FullStory-capture-content-that-is-presented-in-iframes-#h_01F1G333PYKPGZ4B42WDBV3YKV).
  * - recordOnlyThisIFrame: FullStory can record the iFrame as its own unique session. Defaults to `false`. Additional conditions apply and can be found [here](https://help.fullstory.com/hc/en-us/articles/360020622514-Can-FullStory-capture-content-that-is-presented-in-iframes-#h_01F1G33B40Q2TPQA8MA7SF8Y5P).
  * - devMode: In dev mode FullStory won't record sessions. Any calls to SDK methods will `console.warn` that FullStory is in `devMode`. Defaults to `false`.
  */
@@ -31,12 +31,25 @@ type LogLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
 
 type VarScope = 'page';
 
+/**
+ * A callback that will be invoked when FullStory has begun a session.
+ *
+ * `sessionUrl` contains the URL to the current session.
+ */
+type ReadyCallback = ({ sessionUrl: string }) => void;
+
 // API functions that are available as soon as the snippet has executed.
 export function anonymize(): void;
 export function consent(userConsents?: boolean): void;
 export function event(eventName: string, eventProperties: { [key: string]: any }): void;
 export function identify(uid: string, customVars?: UserVars): void;
-export function init(options: SnippetOptions): void;
+/**
+ * Initialize FullStory.
+ *
+ * @param options Options to pass to the snippet.
+ * @param ready If provided, a callback that will be invoked when the FullStory session has begun.
+ */
+export function init(options: SnippetOptions, ready?: ReadyCallback): void;
 export function isInitialized(): boolean;
 export function log(level: LogLevel, msg: string): void;
 export function log(msg: string): void;

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export const restart = guard('restart');
 export const anonymize = guard('anonymize');
 export const setVars = guard('setVars');
 
-const _init = (options) => {
+const _init = (options, ready) => {
   if (fs()) {
     // eslint-disable-next-line no-console
     console.warn('The FullStory snippet has already been defined elsewhere (likely in the <head> element)');
@@ -57,6 +57,10 @@ const _init = (options) => {
   }
 
   snippet(options);
+
+  if (ready) {
+    fs()('observe', { type: 'start', callback: ready });
+  }
 
   if (options.devMode === true) {
     const message = 'FullStory was initialized in devMode and will stop recording';

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export const restart = guard('restart');
 export const anonymize = guard('anonymize');
 export const setVars = guard('setVars');
 
-const _init = (options, ready) => {
+const _init = (options, readyCallback) => {
   if (fs()) {
     // eslint-disable-next-line no-console
     console.warn('The FullStory snippet has already been defined elsewhere (likely in the <head> element)');
@@ -58,8 +58,8 @@ const _init = (options, ready) => {
 
   snippet(options);
 
-  if (ready) {
-    fs()('observe', { type: 'start', callback: ready });
+  if (readyCallback) {
+    fs()('observe', { type: 'start', callback: readyCallback });
   }
 
   if (options.devMode === true) {


### PR DESCRIPTION
This change provides a callback for logic that needs to run after a session has started. The callback is provided with the session URL since it's available from the 'start' event.
