### PR TITLE
Correctly define ReadyCallback parameter type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,7 +36,7 @@ type VarScope = 'page';
  *
  * `sessionUrl` contains the URL to the current session.
  */
-type ReadyCallback = ({ sessionUrl: string }) => void;
+type ReadyCallback = (data: { sessionUrl: string }) => void;
 
 // API functions that are available as soon as the snippet has executed.
 export function anonymize(): void;


### PR DESCRIPTION
The existing `ReadyCallback` type is not valid TypeScript, resulting in a TS error when using the `@fullstory/browser` package.

This issue was introduced in v1.6.0.

This PR adjusts the type definition to be correct.