### PR TITLE
Support loading fs-debug.js when debug=true is passed in options. Fixes #150

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
   "rules": {
     "comma-dangle": ["error", "only-multiline"],
     "no-underscore-dangle": "off",
-    "react/function-component-definition": "off"
+    "react/function-component-definition": "off",
+    "no-console": "off"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,10 @@ const _init = (options, readyCallback) => {
     window._fs_is_outer_script = true;
   }
 
+  if (options.debug && !options.script) {
+    options.script = 'edge.fullstory.com/s/fs-debug.js';
+  }
+
   snippet(options);
 
   if (readyCallback) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,14 +17,14 @@ const hasFullStoryWithFunction = (...testNames) => {
 const guard = (name) => (...args) => {
   if (window._fs_dev_mode) {
     const message = `FullStory is in dev mode and is not recording: ${name} method not executed`;
-    console.warn(message); // eslint-disable-line no-console
+    console.warn(message);
     return message;
   }
 
   if (hasFullStoryWithFunction(name)) {
     return fs()[name](...args);
   }
-  console.warn(`FS.${name} not ready`); // eslint-disable-line no-console
+  console.warn(`FS.${name} not ready`);
   return null;
 };
 
@@ -43,7 +43,6 @@ const _init = (inputOptions, readyCallback) => {
   // Make a copy so we can modify `options` if desired.
   const options = { ...inputOptions };
   if (fs()) {
-    // eslint-disable-next-line no-console
     console.warn('The FullStory snippet has already been defined elsewhere (likely in the <head> element)');
     return;
   }
@@ -58,8 +57,12 @@ const _init = (inputOptions, readyCallback) => {
     window._fs_is_outer_script = true;
   }
 
-  if (options.debug && !options.script) {
-    options.script = 'edge.fullstory.com/s/fs-debug.js';
+  if (options.debug === true) {
+    if (!options.script) {
+      options.script = 'edge.fullstory.com/s/fs-debug.js';
+    } else {
+      console.warn('Ignoring `debug = true` because `script` is set');
+    }
   }
 
   snippet(options);
@@ -75,13 +78,12 @@ const _init = (inputOptions, readyCallback) => {
     });
     shutdown();
     window._fs_dev_mode = true;
-    console.warn(message); // eslint-disable-line no-console
+    console.warn(message);
   }
 };
 
 const initOnce = (fn, message) => (...args) => {
   if (window._fs_initialized) {
-    // eslint-disable-next-line no-console
     if (message) console.warn(message);
     return;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,9 @@ export const restart = guard('restart');
 export const anonymize = guard('anonymize');
 export const setVars = guard('setVars');
 
-const _init = (options, readyCallback) => {
+const _init = (inputOptions, readyCallback) => {
+  // Make a copy so we can modify `options` if desired.
+  const options = { ...inputOptions };
   if (fs()) {
     // eslint-disable-next-line no-console
     console.warn('The FullStory snippet has already been defined elsewhere (likely in the <head> element)');

--- a/test/index.js
+++ b/test/index.js
@@ -85,6 +85,15 @@ describe('init', () => {
     isInit = FullStory.isInitialized();
     expect(isInit).to.equal(true);
   });
+
+  it('should load fs-debug.js when debug is set', () => {
+    FullStory.init({
+      orgId: testOrg,
+      debug: true,
+    });
+
+    expect(window._fs_script).to.match(/fs-debug.js$/);
+  });
 });
 
 describe('devMode', () => {


### PR DESCRIPTION
`fs.js` has been changed to remove debug logging, with a separate `fs-debug.js` provided for that purpose. As such, the snippet no longer honors the `_fs_debug` option. This change makes it so we load `fs-debug.js` when debug logging is requested.
