### PR TITLE
update internal dependency for webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "rollup": "^1.32.1",
         "rollup-plugin-copy": "^3.3.0",
         "typescript": "^3.8.3",
-        "webpack": "^5.38.1"
+        "webpack": "^5.76.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "rollup": "^1.32.1",
     "rollup-plugin-copy": "^3.3.0",
     "typescript": "^3.8.3",
-    "webpack": "^5.38.1"
+    "webpack": "^5.76.1"
   }
 }


### PR DESCRIPTION
a recent pr updated our internal dependencies on webpack but not the dev dependency in the package.json file. this was causing dependabot and snyk automated pr's to have issues. this PR is an attempt to resolve this problem manually.

[valor ticket](https://fullstory.atlassian.net/browse/VAL-7460)

![image](https://user-images.githubusercontent.com/12995427/227377540-80c9a294-1f50-45cf-b6b4-b55bf9e45dc8.png)

recent PR: https://github.com/fullstorydev/fullstory-browser-sdk/commit/d0c8290c65f54f5de2fdf6484cfb8fb5f6b10455
failed snyk request: https://github.com/fullstorydev/fullstory-browser-sdk/pull/167
failed dependabot request: https://github.com/fullstorydev/fullstory-browser-sdk/pull/168