### PR TITLE
updates to README for v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0-beta.4
+- Updates README to 2.x.x
+
 ## 2.0.0-beta.3
 - Official Browser API v2 beta release: https://developer.fullstory.com/browser/v2/getting-started/
 - Add a `startCaptureManually` option to the `init` function to support setting ` _fs_capture_on_startup`: https://developer.fullstory.com/browser/v2/auto-capture/capture-data/#manually-delay-data-capture

--- a/README.md
+++ b/README.md
@@ -18,6 +18,47 @@ npm i @fullstory/browser --save
 yarn add @fullstory/browser
 ```
 
+## Migrating to Version 2.0.0
+In version 2.0.0, `init` is a separate named export from `FullStory`. You will need to update all of your wildcard (`'*'`) imports to explicit named imports.
+
+**Version 1.x.x**
+```js
+import * as FullStory from '@fullstory/browser';
+```
+
+**Version 2.x.x**
+```js
+import { FullStory, init } from '@fullstory/browser';
+```
+
+You can use `init` by itself in the same way you used it in version 1.
+
+**Version 2.x.x**
+```js
+import { init } from '@fullstory/browser';
+
+init({ orgId: 'my-org-id' })
+```
+You can also rename the function for readability.
+```js
+import { init as initFullStory } from '@fullstory/browser';
+
+initFullStory({ orgId: 'my-org-id' })
+```
+
+The `FullStory` named export is equivalent to the global `FS` object described in the [developer documentation](https://developer.fullstory.com/browser/v2/getting-started/). You can use it to make all version 2 API calls:
+```js
+import { FullStory } from '@fullstory/browser';
+
+FullStory('trackEvent', {
+  name: 'My Event',
+  properties: {
+    product: 'Sprockets',
+    quantity: 1,
+  },
+})
+```
+
 ## Initialize the SDK
 
 Call the `init()` function with options as soon as you can in your website startup process. Calling init after successful initialization will trigger console warnings - if you need to programmatically check if FullStory has been initialized at some point in your code, you can call `isInitialized()`.
@@ -43,7 +84,9 @@ The only required option is `orgId`, all others are optional.
 The `init` function also accepts an optional `readyCallback` argument. If you provide a function, it will be invoked when the FullStory session has started. Your callback will be called with one parameter: an object containing information about the session. Currently the only property is `sessionUrl`, which is a string containing the URL to the session.
 
 ```javascript
-FullStory.init({ orgId }, ({ sessionUrl }) => console.log(`Started session: ${sessionUrl}`));
+import { init } from '@fullstory/browser';
+
+init({ orgId }, ({ sessionUrl }) => console.log(`Started session: ${sessionUrl}`));
 ```
 
 ### Initialization Examples
@@ -55,10 +98,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-import * as FullStory from '@fullstory/browser';
+import { init as initFullStory } from '@fullstory/browser';
 
 
-FullStory.init({ orgId: '<your org id here>' });
+initFullStory({ orgId: '<your org id here>' });
 
 ReactDOM.render(<App />, document.getElementById('root'));
 ```
@@ -67,7 +110,7 @@ ReactDOM.render(<App />, document.getElementById('root'));
 
 ```javascript
 import { Component } from '@angular/core';
-import * as FullStory from '@fullstory/browser';
+import { init as initFullStory } from '@fullstory/browser';
 import { environment } from '../environments/environment';
 
 @Component({
@@ -78,7 +121,7 @@ import { environment } from '../environments/environment';
 export class AppComponent {
 
   constructor() {
-    FullStory.init({ orgId: '<your org id here>',
+    initFullStory({ orgId: '<your org id here>',
       devMode: !environment.production });
   }
 }
@@ -89,9 +132,9 @@ export class AppComponent {
 ```javascript
 import Vue from 'vue';
 import App from './App.vue';
-import * as FullStory from '@fullstory/browser';
+import { init as initFullStory } from '@fullstory/browser';
 
-FullStory.init({ orgId: '<your org id here>' });
+initFullStory({ orgId: '<your org id here>' });
 Vue.prototype.$FullStory = FullStory;
 
 new Vue({
@@ -102,11 +145,11 @@ new Vue({
 #### Vue 3
 
 ```javascript
-import { createApp } from 'vue'
-import App from './App.vue'
-import * as FullStory from '@fullstory/browser';
+import { createApp } from 'vue';
+import App from './App.vue';
+import { init as initFullStory } from '@fullstory/browser';
 
-FullStory.init({ orgId: '<your org id here>' });
+initFullStory({ orgId: '<your org id here>' });
 
 const app = createApp(App);
 app.config.globalProperties.$FullStory = FullStory;
@@ -115,34 +158,51 @@ app.mount('#app');
 
 ## Using the SDK
 
-Once FullStory is initialized, you can make calls to the FullStory SDK.
+Once FullStory is initialized, you can make calls to the FullStory SDK. See the [developer documentation](https://developer.fullstory.com/browser/v2/getting-started/) for more information.
 
 ### Sending custom events
 
 ```JavaScript
-FullStory.event('Subscribed', {
-  uid_str: '750948353',
-  plan_name_str: 'Professional',
-  plan_price_real: 299,
-  plan_users_int: 10,
-  days_in_trial_int: 42,
-  feature_packs: ['MAPS', 'DEV', 'DATA'],
+FullStory('trackEvent', {
+  name: 'Subscribed',
+  properties: {
+    uid: '750948353',
+    plan_name: 'Professional',
+    plan_price: 299,
+    plan_users: 10,
+    days_in_trial: 42,
+    feature_packs: ['MAPS', 'DEV', 'DATA'],
+  },
+  schema: {
+    properties: {
+      plan_users: 'int',
+      days_in_trial: 'int',
+    }
+  }
 });
 ```
 
 ### Generating session replay links
 
 ```JavaScript
-const startOfPlayback = FullStory.getCurrentSessionURL();
-const playbackAtThisMomentInTime = FullStory.getCurrentSessionURL(true);
+const startOfPlayback = FullStory('getSession');
+const playbackAtThisMomentInTime = FullStory('getSession', { format: 'url.now' });
 ```
 
 ### Sending custom page data
 ```JavaScript
-FullStory.setVars('page', {
- pageName : 'Checkout', // what is the name of the page?
- cart_size_int : 10, // how many items were in the cart?
- used_coupon_bool : true, // was a coupon used?
+FullStory('setProperties', {
+  type: 'page',
+  properties: {
+    pageName: 'Checkout', // what is the name of the page?
+    cart_size: 10, // how many items were in the cart?
+    used_coupon: true, // was a coupon used?
+  },
+  schema: {
+    properties: {
+      cart_size: 'int', // override default "real" inference with "int"
+    }
+  }
 });
 ```
 For more information on setting page vars, view the FullStory help article on [Sending custom page data to FullStory](https://help.fullstory.com/hc/en-us/articles/1500004101581-FS-setVars-API-Sending-custom-page-data-to-FullStory).

--- a/README.md
+++ b/README.md
@@ -21,31 +21,32 @@ yarn add @fullstory/browser
 ## Migrating to Version 2.0.0
 In version 2.0.0, `init` is a separate named export from `FullStory`. You will need to update all of your wildcard (`'*'`) imports to explicit named imports.
 
-**Version 1.x.x**
+_Version 1.x.x_
 ```js
 import * as FullStory from '@fullstory/browser';
 ```
 
-**Version 2.x.x**
+_Version 2.x.x_
 ```js
 import { FullStory, init } from '@fullstory/browser';
 ```
 
-You can use `init` by itself in the same way you used it in version 1.
+### `init`
+You can use the named import `init` by itself:
 
-**Version 2.x.x**
 ```js
 import { init } from '@fullstory/browser';
 
 init({ orgId: 'my-org-id' })
 ```
-You can also rename the function for readability.
+You can also rename the function for readability:
 ```js
 import { init as initFullStory } from '@fullstory/browser';
 
 initFullStory({ orgId: 'my-org-id' })
 ```
 
+### `FullStory`
 The `FullStory` named export is equivalent to the global `FS` object described in the [developer documentation](https://developer.fullstory.com/browser/v2/getting-started/). You can use it to make all version 2 API calls:
 ```js
 import { FullStory } from '@fullstory/browser';
@@ -121,8 +122,10 @@ import { environment } from '../environments/environment';
 export class AppComponent {
 
   constructor() {
-    initFullStory({ orgId: '<your org id here>',
-      devMode: !environment.production });
+    initFullStory({
+      orgId: '<your org id here>',
+      devMode: !environment.production,
+    });
   }
 }
 ```
@@ -132,7 +135,7 @@ export class AppComponent {
 ```javascript
 import Vue from 'vue';
 import App from './App.vue';
-import { init as initFullStory } from '@fullstory/browser';
+import { init as initFullStory, FullStory } from '@fullstory/browser';
 
 initFullStory({ orgId: '<your org id here>' });
 Vue.prototype.$FullStory = FullStory;
@@ -147,7 +150,7 @@ new Vue({
 ```javascript
 import { createApp } from 'vue';
 import App from './App.vue';
-import { init as initFullStory } from '@fullstory/browser';
+import { init as initFullStory, FullStory } from '@fullstory/browser';
 
 initFullStory({ orgId: '<your org id here>' });
 
@@ -206,6 +209,3 @@ FullStory('setProperties', {
 });
 ```
 For more information on setting page vars, view the FullStory help article on [Sending custom page data to FullStory](https://help.fullstory.com/hc/en-us/articles/1500004101581-FS-setVars-API-Sending-custom-page-data-to-FullStory).
-
-#### Note
-`FullStory.setVars(<scope>, <payload>)` currently only supports a string value of "page" for the scope. Using arbitrary strings for the scope parameter will result in an Error that will be logged to the browser console or discarded, depending on whether devMode or debug is enabled.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ FullStory('setProperties', {
   },
   schema: {
     properties: {
-      cart_size: 'int', // override default "real" inference with "int"
+      cart_size: 'int', // override default inferred "real" type with "int"
     }
   }
 });

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 FullStory's browser SDK lets you manage FullStory recording on your site as well as retrieve deep links to session replays and send your own custom events. More information about the FullStory API can be found at https://developer.fullstory.com.
 
+> **NOTE:** this is the documentation for version 2. For version 1 documentation, please see [@fullstory/browser@1.7.1](https://www.npmjs.com/package/@fullstory/browser/v/1.7.1).
 
 ## Install the SDK
 
@@ -18,8 +19,8 @@ npm i @fullstory/browser --save
 yarn add @fullstory/browser
 ```
 
-## Migrating to Version 2.0.0
-In version 2.0.0, `init` is a separate named export from `FullStory`. You will need to update all of your wildcard (`'*'`) imports to explicit named imports.
+## Migrating to Version 2.x.x
+In version 2.x.x, `init` is a separate named export from `FullStory`. You will need to update all of your wildcard (`'*'`) imports to explicit named imports.
 
 _Version 1.x.x_
 ```js
@@ -178,12 +179,14 @@ FullStory('trackEvent', {
   },
   schema: {
     properties: {
-      plan_users: 'int',
-      days_in_trial: 'int',
+      plan_users: 'int', // override default inferred "real" type with "int"
+      days_in_trial: 'int', // override default inferred "real" type with "int"
     }
   }
 });
 ```
+
+> **NOTE:** The inclusion of type suffixes - appending `_str` or `_int` to the end of properties - is no longer required. All custom properties are inferred on the server. To override any default inference, you can add a `schema`. See [Custom Properties](https://developer.fullstory.com/browser/v2/custom-properties/) for more information.
 
 ### Generating session replay links
 
@@ -192,7 +195,22 @@ const startOfPlayback = FullStory('getSession');
 const playbackAtThisMomentInTime = FullStory('getSession', { format: 'url.now' });
 ```
 
-### Sending custom page data
+### Sending custom user properties
+```JavaScript
+FullStory('setProperties', {
+  type: 'user',
+  properties: {
+    displayName: 'Daniel Falko',
+    email: 'daniel.falko@example.com',
+    pricing_plan: 'free',
+    popup_help: true,
+    total_spent: 14.50,
+  },
+});
+```
+For more information on sending custom user properties, view the FullStory help article on [Capturing custom user properties](https://help.fullstory.com/hc/en-us/articles/360020623294).
+
+### Sending custom page properties
 ```JavaScript
 FullStory('setProperties', {
   type: 'page',
@@ -208,4 +226,4 @@ FullStory('setProperties', {
   }
 });
 ```
-For more information on setting page vars, view the FullStory help article on [Sending custom page data to FullStory](https://help.fullstory.com/hc/en-us/articles/1500004101581-FS-setVars-API-Sending-custom-page-data-to-FullStory).
+For more information on setting page properties, view the FullStory help article on [Sending custom page data to FullStory](https://help.fullstory.com/hc/en-us/articles/1500004101581-FS-setVars-API-Sending-custom-page-data-to-FullStory).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/browser",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/browser",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@fullstory/snippet": "2.0.0-beta.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/browser",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "The official FullStory browser SDK",
   "repository": "git://github.com/fullstorydev/fullstory-browser-sdk.git",
   "homepage": "https://github.com/fullstorydev/fullstory-browser-sdk",


### PR DESCRIPTION
For some reason, I thought I'd done this with the first beta release. I need to link to this (esp the upgrading section) in the beta release dev docs.

There are a couple of options here. We could either:
- Merge with a disclaimer at the top that this is the beta README and to go to `<insert link>` for version one.
- Keep this on a branch. Looks like I can still [deep link](https://github.com/fullstorydev/fullstory-browser-sdk/blob/scottnorvell/v2-readme-updates/README.md#migrating-to-version-200) to the README from the branch and it is available to the public. (at least an incognito window)

Thoughts on the above?