### PR TITLE
Prepare release 2.1.0 beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.0-beta.0
+-  Beta release using snippet 2.1. Changes are largely under the hood. Uses the 2.1 version of the fullstory snippet.
+
 ## 2.0.8
 - Add sessionUid option to init for session UID passthrough
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/browser",
-  "version": "2.0.8",
+  "version": "2.1.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/browser",
-      "version": "2.0.8",
+      "version": "2.1.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@fullstory/snippet": "2.1.0-beta.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/browser",
-  "version": "2.0.8",
+  "version": "2.1.0-beta.0",
   "description": "The official Fullstory browser SDK",
   "repository": "git://github.com/fullstorydev/fullstory-browser-sdk.git",
   "homepage": "https://github.com/fullstorydev/fullstory-browser-sdk",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog/lockfile metadata only; no SDK source changes in the PR diff.
> 
> **Overview**
> **Release cut** for `@fullstory/browser` **2.1.0-beta.0**, aligning the published package with **`@fullstory/snippet` 2.1.0-beta.0** (snippet 2.1; behavior described as mostly under the hood).
> 
> Updates **`package.json`**, **`package-lock.json`**, and **`CHANGELOG.md`** only—no application source changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e76508f6392fec7ad762f76232fe5f5588d70a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->