### PR TITLE
[WECA-168] prepare 2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Fullstory's browser SDK lets you manage Fullstory data capture on your site as well as retrieve deep links to session replays and send your own custom events. More information about the Fullstory API can be found at https://developer.fullstory.com.
 
+Version 2.1.0 updates the sdk to use v2.1 of the Fullstory snippet. No external updates are required. Please reference our developer docs for a list of [what's new in Snippet 2.1](https://developer.fullstory.com/browser/getting-started/#whats-new-in-version-21).
+
 > **NOTE:** this is the documentation for version 2. For version 1 documentation, please see [@fullstory/browser@1.7.1](https://www.npmjs.com/package/@fullstory/browser/v/1.7.1).
 
 ## Install the SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/browser",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/browser",
-      "version": "2.1.0-beta.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@fullstory/snippet": "2.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@fullstory/snippet": "2.1.0-beta.0"
+        "@fullstory/snippet": "2.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.8.7",
@@ -2114,9 +2114,9 @@
       }
     },
     "node_modules/@fullstory/snippet": {
-      "version": "2.1.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@fullstory/snippet/-/snippet-2.1.0-beta.0.tgz",
-      "integrity": "sha512-xMlcRvzzE0Eg0B+P0rS9fHIz1Q0Sam9zCZuB0CT7DopyX3bg+qA0AnxFoffrEJZPKDT6KXk2bmLoyV6vRKvwDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fullstory/snippet/-/snippet-2.1.0.tgz",
+      "integrity": "sha512-iuwwwa9AG9OSBnKoPxGdX69Hyu3tX1pw1rhuB02RArpeGW7jnUpDnIOrn0Y07B2PSTJqiQzp1b4P/jLzHCI9Ew==",
       "license": "ISC"
     },
     "node_modules/@humanfs/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7680,9 +7680,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "sdk"
   ],
   "dependencies": {
-    "@fullstory/snippet": "2.1.0-beta.0"
+    "@fullstory/snippet": "2.1.0"
   },
   "overrides": {
     "brace-expansion": "^5.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/browser",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0",
   "description": "The official Fullstory browser SDK",
   "repository": "git://github.com/fullstorydev/fullstory-browser-sdk.git",
   "homepage": "https://github.com/fullstorydev/fullstory-browser-sdk",


### PR DESCRIPTION
Bumps browser sdk to 2.1.0 with snippet 2.1

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e404c7464291e5f4944716440cdf70eb3cdaaf58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->